### PR TITLE
Update __init__.py

### DIFF
--- a/ncfacbot/__init__.py
+++ b/ncfacbot/__init__.py
@@ -3,8 +3,6 @@
 # stdlib
 import calendar
 from datetime import datetime, timezone
-from math import trunc
-from time import mktime
 # 3rd party
 from aethersprite.common import FIFTEEN_MINS
 
@@ -17,7 +15,7 @@ def discord_timestamp(dt: datetime):
     :returns: A formatted Discord timestamp string
     """
 
-    stamp = trunc(mktime(dt.timetuple()))
+    stamp = calendar.timegm(dt.timetuple())
 
     return f'<t:{stamp}>'
 


### PR DESCRIPTION
Apparently, the way to go for times in utc is calendar.timegm instead of time.mktime (old code was made for local times),
according to [python3 docs for time library](https://docs.python.org/3/library/time.html) "Use the following functions to convert between time representations:"
Also, this does return as integer so no need for math.trunc
This time formatting did weird things and I'd exect it not do do so anymore