### PR TITLE
Smarter time-only raid scheduling

### DIFF
--- a/ncfacbot/raid.py
+++ b/ncfacbot/raid.py
@@ -268,6 +268,8 @@ class Raid(Cog, name='raid'):
             else:
                 dt = datetime.strptime(f'{dt.strftime("%Y-%m-%d")} {when} '
                                        '+0000', INPUT_FORMAT)
+                if dt < datetime.now(timezone.utc):
+                    dt = dt + timedelta(days=1)
         except:
             await ctx.message.add_reaction(THUMBS_DOWN)
             log.warning(f'{ctx.author} provided bad args: {when}')


### PR DESCRIPTION
Instead of assuming the raid is scheduled for the current day, it's scheduled in the next 24h
Do this by adding 1 day to the raid schedule if it would otherwise be scheduled in the past